### PR TITLE
Bug fix for ISSUE 5

### DIFF
--- a/functions/private/helpers.ps1
+++ b/functions/private/helpers.ps1
@@ -15,7 +15,9 @@ function _newWorkItem {
     $item.taskmodified = $data.TaskModified -as [datetime]
     $item.Completed = $data.completed
     $item.taskId = $data.TaskId
+    if ($path -ne '') {
     $item.path = Convert-Path $path
+    }
 
     $item | Select-Object * | Out-String | Write-Debug
     $item

--- a/functions/public/Complete-PSWorkItem.ps1
+++ b/functions/public/Complete-PSWorkItem.ps1
@@ -126,7 +126,7 @@ Function Complete-PSWorkItem {
                     $splat.Query = "SELECT *,RowID from archive WHERE taskid = '$($task.taskid)'"
                     Try {
                         $pass = Invoke-MySQLiteQuery @splat
-                        $t = _newWorkItem $pass
+                        $t = _newWorkItem $pass -$path $Path
                         #insert a new typename
                         $t.psobject.typenames.insert(0,"PSWorkItemArchive")
                         $t

--- a/functions/public/New-PSWorkItem.ps1
+++ b/functions/public/New-PSWorkItem.ps1
@@ -112,7 +112,7 @@ Function New-PSWorkItem {
                     Write-Verbose "[$((Get-Date).TimeofDay) PROCESS] $($myinvocation.mycommand): $($splat.query)"
                     $data = Invoke-MySQLiteQuery @splat
                     $data | Out-String | Write-Verbose
-                    _newWorkItem $data
+                    _newWorkItem $data -path $Path
                 }
             }
         }


### PR DESCRIPTION
Updated New-PSWorkItem and Complete-PSWorkItem to include -Path when calling _newWorkItem.

Also updated _newWorkItem to skip call to Convert-Path when $path is an empty string.